### PR TITLE
Add support for more operating systems. Fixes #3

### DIFF
--- a/setup-min.sh
+++ b/setup-min.sh
@@ -96,6 +96,8 @@ elif [ "$(uname | grep -i 'Linux')" ]; then
     OS='ubuntu'
   elif [ "$(cat /etc/issue | grep -i 'elementary OS')" ]; then
     OS='ubuntu'
+   elif [ "$(cat /etc/issue | grep -i 'Debian')" ]; then
+    OS='ubuntu'
   elif [ "$(cat /etc/issue | grep -i 'Raspbian')" ]; then
     OS='raspbian'
   elif [ "$(cat /etc/issue | grep -i 'Fedora')" ]; then

--- a/setup-min.sh
+++ b/setup-min.sh
@@ -94,6 +94,8 @@ elif [ "$(uname | grep -i 'Linux')" ]; then
     OS='ubuntu'
   elif [ "$(cat /etc/issue | grep -i 'Raspbian')" ]; then
     OS='raspbian'
+  elif [ "$(cat /etc/issue | grep -i 'Linux Mint')" ]; then
+    OS='ubuntu'
   elif [ "$(cat /etc/issue | grep -i 'Fedora')" ]; then
     OS='fedora'
   fi

--- a/setup-min.sh
+++ b/setup-min.sh
@@ -92,10 +92,10 @@ elif [ "$(uname | grep -i 'Linux')" ]; then
 
   if [ "$(cat /etc/issue | grep -i 'Ubuntu')" ]; then
     OS='ubuntu'
-  elif [ "$(cat /etc/issue | grep -i 'Raspbian')" ]; then
-    OS='raspbian'
   elif [ "$(cat /etc/issue | grep -i 'Linux Mint')" ]; then
     OS='ubuntu'
+  elif [ "$(cat /etc/issue | grep -i 'Raspbian')" ]; then
+    OS='raspbian'
   elif [ "$(cat /etc/issue | grep -i 'Fedora')" ]; then
     OS='fedora'
   fi

--- a/setup-min.sh
+++ b/setup-min.sh
@@ -96,7 +96,9 @@ elif [ "$(uname | grep -i 'Linux')" ]; then
     OS='ubuntu'
   elif [ "$(cat /etc/issue | grep -i 'elementary OS')" ]; then
     OS='ubuntu'
-   elif [ "$(cat /etc/issue | grep -i 'Debian')" ]; then
+  elif [ "$(cat /etc/issue | grep -i 'Debian')" ]; then
+    OS='ubuntu'
+  elif [ "$(cat /etc/issue | grep -i 'Trisquel')" ]; then
     OS='ubuntu'
   elif [ "$(cat /etc/issue | grep -i 'Raspbian')" ]; then
     OS='raspbian'

--- a/setup-min.sh
+++ b/setup-min.sh
@@ -94,6 +94,8 @@ elif [ "$(uname | grep -i 'Linux')" ]; then
     OS='ubuntu'
   elif [ "$(cat /etc/issue | grep -i 'Linux Mint')" ]; then
     OS='ubuntu'
+  elif [ "$(cat /etc/issue | grep -i 'elementary OS')" ]; then
+    OS='ubuntu'
   elif [ "$(cat /etc/issue | grep -i 'Raspbian')" ]; then
     OS='raspbian'
   elif [ "$(cat /etc/issue | grep -i 'Fedora')" ]; then

--- a/setup.bash
+++ b/setup.bash
@@ -98,6 +98,8 @@ elif [ "$(uname | grep -i 'Linux')" ]; then
     OS='ubuntu'
   elif [ "$(cat /etc/issue | grep -i 'Debian')" ]; then
     OS='ubuntu'
+  elif [ "$(cat /etc/issue | grep -i 'Trisquel')" ]; then
+    OS='ubuntu'
   elif [ "$(cat /etc/issue | grep -i 'Raspbian')" ]; then
     OS='raspbian'
   elif [ "$(cat /etc/issue | grep -i 'Fedora')" ]; then

--- a/setup.bash
+++ b/setup.bash
@@ -96,6 +96,8 @@ elif [ "$(uname | grep -i 'Linux')" ]; then
     OS='ubuntu'
   elif [ "$(cat /etc/issue | grep -i 'elementary OS')" ]; then
     OS='ubuntu'
+  elif [ "$(cat /etc/issue | grep -i 'Debian')" ]; then
+    OS='ubuntu'
   elif [ "$(cat /etc/issue | grep -i 'Raspbian')" ]; then
     OS='raspbian'
   elif [ "$(cat /etc/issue | grep -i 'Fedora')" ]; then

--- a/setup.bash
+++ b/setup.bash
@@ -94,6 +94,8 @@ elif [ "$(uname | grep -i 'Linux')" ]; then
     OS='ubuntu'
   elif [ "$(cat /etc/issue | grep -i 'Linux Mint')" ]; then
     OS='ubuntu'
+  elif [ "$(cat /etc/issue | grep -i 'elementary OS')" ]; then
+    OS='ubuntu'
   elif [ "$(cat /etc/issue | grep -i 'Raspbian')" ]; then
     OS='raspbian'
   elif [ "$(cat /etc/issue | grep -i 'Fedora')" ]; then

--- a/setup.bash
+++ b/setup.bash
@@ -92,6 +92,8 @@ elif [ "$(uname | grep -i 'Linux')" ]; then
 
   if [ "$(cat /etc/issue | grep -i 'Ubuntu')" ]; then
     OS='ubuntu'
+  elif [ "$(cat /etc/issue | grep -i 'Linux Mint')" ]; then
+    OS='ubuntu'
   elif [ "$(cat /etc/issue | grep -i 'Raspbian')" ]; then
     OS='raspbian'
   elif [ "$(cat /etc/issue | grep -i 'Fedora')" ]; then


### PR DESCRIPTION
This adds Linux Mint, Debian, Trisquel and Elementary OS support. For the purpose of this script they are simply the same as Ubuntu. It has been tested and works for installing node on all of the above.
